### PR TITLE
Refactor Nodejs example

### DIFF
--- a/NodeJS/README.md
+++ b/NodeJS/README.md
@@ -18,6 +18,7 @@ This is just like the other workers, except it's written in NodeJS.
 
     % node test-script
     Starting Camunda Cloud Zeebe ScriptWorker
+    Handling jobs of type DoMathTask
     ===================================
     14:00:56.071 | zeebe |  INFO: Authenticating client with Camunda Cloud...
     Handling job:  2251799814893972
@@ -37,7 +38,7 @@ The Node.js client is not an officially supported client library, but since Node
 The NodeJS example is even shorter than the others.
 
 ```js
-const ZB = require('zeebe-node');
+const { ZBClient } = require('zeebe-node');
 
 // Change this if you changed the task name in the BPMN file
 const PROC_NAME = 'DoMathTask';
@@ -46,33 +47,37 @@ const DEBUG = true;
 
 if (DEBUG) {
   console.log("Starting Camunda Cloud Zeebe ScriptWorker")
+  console.log(`Handling jobs of type ${PROC_NAME}`)
   console.log("===================================")
-}
-  ; (async () => {
-    const zbc = new ZB.ZBClient()
-    zbc.createWorker(PROC_NAME, (job) => {
-      if (DEBUG) {
-        console.log("Handling job: ", job.key)
-      }
-      if (job.variables.count === undefined) {
-        job.variables.count = 0
-      }
-      if (job.variables.add === undefined) {
-        job.variables.add = 0
-      }
-      if (DEBUG) {
-        console.log("Incoming variables: ", job.variables)
-      }
-      job.variables.count = job.variables.count + job.variables.add
-      if (DEBUG) {
-        console.log("Job Complete: ", job.variables)
-      }
-      job.complete(job.variables)
+} 
+
+const zbc = new ZBClient();
+
+zbc.createWorker({
+  taskType: PROC_NAME, 
+  taskHandler: job => {
+    if (DEBUG) {
+      console.log("Handling job: ", job.key)
+      console.log("Incoming variables: ", job.variables)
+    }
+
+    const count = job.variables.count ?? 0
+    const add = job.variables ?? 0
+    const newCount = count + add
+
+    if (DEBUG) {
+      console.log("Job Complete: ", {...job.variables, add, count: newCount})
+    }
+
+    job.complete({ 
+      add,
+      count: newCount
     })
-  })()
+  }
+})
 ```
 
-Again, we define the task name to listen for, and then start a worker to listen for those tasks. We then get the process variables `count` and `add` (if they exist or we create them if they don't), add them together, and return the result.  Once again, to run this worker:
+Again, we define the task name to listen for, and then start a worker to listen for those tasks. We then get the process variables `count` and `add` (if they exist or we default them to zero if they don't, using nullish coalescing), add them together, and return the result.  Once again, to run this worker:
 
 ```shell
 % export ZEEBE_ADDRESS=YOUR_CLUSTER.bru-2.zeebe.camunda.io:443

--- a/NodeJS/package.json
+++ b/NodeJS/package.json
@@ -4,7 +4,7 @@
   "description": "Camunda Platform 8 Script Workers",
   "main": "test-script.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Chuck Norris tests in production!\" && exit 0"
   },
   "repository": {
     "type": "git",

--- a/NodeJS/test-script.js
+++ b/NodeJS/test-script.js
@@ -23,28 +23,31 @@ const DEBUG = true;
 
 if (DEBUG) {
   console.log("Starting Camunda Cloud Zeebe ScriptWorker")
+  console.log(`Handling jobs of type ${PROC_NAME}`)
   console.log("===================================")
-}
-; (async () => {
-  const zbc = new ZBClient();
+} 
 
-  zbc.createWorker(PROC_NAME, (job) => {
-      if (DEBUG) {
-        console.log("Handling job: ", job.key)
-      }
-      if (job.variables.count === undefined) {
-        job.variables.count = 0
-      }
-      if (job.variables.add === undefined) {
-        job.variables.add = 0
-      }
-      if (DEBUG) {
-        console.log("Incoming variables: ", job.variables)
-      }
-      job.variables.count = job.variables.count + job.variables.add
-      if (DEBUG) {
-        console.log("Job Complete: ", job.variables)
-      }
-      job.complete(job.variables)
+const zbc = new ZBClient();
+
+zbc.createWorker({
+  taskType: PROC_NAME, 
+  taskHandler: job => {
+    if (DEBUG) {
+      console.log("Handling job: ", job.key)
+      console.log("Incoming variables: ", job.variables)
+    }
+
+    const count = job.variables.count ?? 0
+    const add = job.variables ?? 0
+    const newCount = count + add
+
+    if (DEBUG) {
+      console.log("Job Complete: ", {...job.variables, add, count: newCount})
+    }
+
+    job.complete({ 
+      add,
+      count: newCount
     })
-  })()
+  }
+})


### PR DESCRIPTION
This refactors the NodeJS example. 

You can use [nullish coalescing](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator) instead of testing for undefined with an if statement. 

Also, the job.variables is typed as readonly in TypeScript. I didn't freeze it to make it immutable at runtime, because that would impact performance - but you can't transpile job.variable mutations from TS to JS.